### PR TITLE
Refs #20: Display URL of uploaded graph

### DIFF
--- a/CyGraphSpaceApp/.classpath
+++ b/CyGraphSpaceApp/.classpath
@@ -14,6 +14,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
@@ -22,7 +23,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="miglayout15-swing.jar" sourcepath="miglayout-src.zip"/>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/CyGraphSpaceApp/.settings/org.eclipse.jdt.core.prefs
+++ b/CyGraphSpaceApp/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,13 @@
 eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.8

--- a/CyGraphSpaceApp/pom.xml
+++ b/CyGraphSpaceApp/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.cytoscape.graphspace</groupId>
     <artifactId>CyGraphSpace</artifactId>
-    <version>1.0.0-beta</version>
+    <version>1.0.1-beta</version>
 
     <name>CyGraphSpace</name>
 

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyActivator.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyActivator.java
@@ -12,6 +12,7 @@ import org.cytoscape.application.swing.CySwingApplication;
 import org.cytoscape.model.CyNetworkFactory;
 import org.cytoscape.model.CyNetworkManager;
 import org.cytoscape.model.subnetwork.CyRootNetworkManager;
+import org.cytoscape.graphspace.cygraphspace.internal.gui.CyGraphSpaceResultPanel;
 import org.cytoscape.graphspace.cygraphspace.internal.gui.GetGraphsPanel;
 import org.cytoscape.graphspace.cygraphspace.internal.gui.PostGraphToolBarComponent;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.CyObjectManager;
@@ -34,60 +35,63 @@ import org.osgi.framework.BundleContext;
  */
 public class CyActivator extends AbstractCyActivator {
 
-    @SuppressWarnings("rawtypes")
+	@SuppressWarnings("rawtypes")
 	@Override
-    public void start(BundleContext context) throws Exception {
-        CyApplicationManager applicationManager = getService(context, CyApplicationManager.class);
+	public void start(BundleContext context) throws Exception {
+		CyApplicationManager applicationManager = getService(context, CyApplicationManager.class);
 
-        AbstractCyAction action = null;
-        Properties properties = null;
-        BundleContext bc = context;
+		AbstractCyAction action = null;
+		Properties properties = null;
+		BundleContext bc = context;
 
-        //register Post Graph Action
-        action = new CyGraphSpaceMenuAction(MessageConfig.MenuActionTitle);
-        properties = new Properties();
-        registerService(context, action, CyAction.class, properties);
+		//register Post Graph Action
+		action = new CyGraphSpaceMenuAction(MessageConfig.MenuActionTitle);
+		properties = new Properties();
+		registerService(context, action, CyAction.class, properties);
 
-        //getting cytoscape services
-        CyApplicationConfiguration config = getService(context,CyApplicationConfiguration.class);
-        CySwingAppAdapter appAdapter = getService(context, CySwingAppAdapter.class);
-        CySwingApplication desktop = getService(bc,CySwingApplication.class);
-        LoadNetworkFileTaskFactory loadNetworkFileTaskFactory = getService(bc, LoadNetworkFileTaskFactory.class);
-        ExportNetworkTaskFactory exportNetworkTaskFactory = getService(bc, ExportNetworkTaskFactory.class);
-        ExportNetworkViewTaskFactory exportNetworkViewTaskFactory = getService(bc, ExportNetworkViewTaskFactory.class);
-        LoadVizmapFileTaskFactory loadVizmapFileTaskFactory = getService(bc, LoadVizmapFileTaskFactory.class);
-        ExportVizmapTaskFactory exportVizmapTaskFactory = getService(bc, ExportVizmapTaskFactory.class);
-        TaskManager taskManager = getService(context, DialogTaskManager.class);
-        final CyNetworkFactory cyNetworkFactory = getService(bc, CyNetworkFactory.class);
+		//getting cytoscape services
+		CyApplicationConfiguration config = getService(context,CyApplicationConfiguration.class);
+		CySwingAppAdapter appAdapter = getService(context, CySwingAppAdapter.class);
+		CySwingApplication desktop = getService(bc,CySwingApplication.class);
+		LoadNetworkFileTaskFactory loadNetworkFileTaskFactory = getService(bc, LoadNetworkFileTaskFactory.class);
+		ExportNetworkTaskFactory exportNetworkTaskFactory = getService(bc, ExportNetworkTaskFactory.class);
+		ExportNetworkViewTaskFactory exportNetworkViewTaskFactory = getService(bc, ExportNetworkViewTaskFactory.class);
+		LoadVizmapFileTaskFactory loadVizmapFileTaskFactory = getService(bc, LoadVizmapFileTaskFactory.class);
+		ExportVizmapTaskFactory exportVizmapTaskFactory = getService(bc, ExportVizmapTaskFactory.class);
+		TaskManager taskManager = getService(context, DialogTaskManager.class);
+		final CyNetworkFactory cyNetworkFactory = getService(bc, CyNetworkFactory.class);
 		final CyNetworkManager cyNetworkManager = getService(bc, CyNetworkManager.class);
 		final CyRootNetworkManager cyRootNetworkManager = getService(bc, CyRootNetworkManager.class);
-		
-        //Register these with the CyObjectManager singleton.
-        CyObjectManager manager = CyObjectManager.INSTANCE;
-        File configDir = config.getAppConfigurationDirectoryLocation(CyActivator.class);
-        configDir.mkdirs();
-        
-        //setting services to manager singleton
-        manager.setCyApplicationManager(applicationManager);
-        manager.setConfigDir(configDir);
-        manager.setCySwingAppAdapter(appAdapter);
-        manager.setCySwingApplition(desktop);
-        manager.setLoadNetworkFileTaskFactory(loadNetworkFileTaskFactory);
-        manager.setExportNetworkTaskFactory(exportNetworkTaskFactory);
-        manager.setExportNetworkViewTaskFactory(exportNetworkViewTaskFactory);
-        manager.setLoadVizmapTaskFactory(loadVizmapFileTaskFactory);
-        manager.setExportVizmapTaskFactory(exportVizmapTaskFactory);
+
+		//Register these with the CyObjectManager singleton.
+		CyObjectManager manager = CyObjectManager.INSTANCE;
+		File configDir = config.getAppConfigurationDirectoryLocation(CyActivator.class);
+		configDir.mkdirs();
+
+		//setting services to manager singleton
+		manager.setCyApplicationManager(applicationManager);
+		manager.setConfigDir(configDir);
+		manager.setCySwingAppAdapter(appAdapter);
+		manager.setCySwingApplition(desktop);
+		manager.setLoadNetworkFileTaskFactory(loadNetworkFileTaskFactory);
+		manager.setExportNetworkTaskFactory(exportNetworkTaskFactory);
+		manager.setExportNetworkViewTaskFactory(exportNetworkViewTaskFactory);
+		manager.setLoadVizmapTaskFactory(loadVizmapFileTaskFactory);
+		manager.setExportVizmapTaskFactory(exportVizmapTaskFactory);
 		manager.setCyNetworkFactory(cyNetworkFactory);
 		manager.setCyNetworkManager(cyNetworkManager);
 		manager.setCyRootNetworkManager(cyRootNetworkManager);
-        
-        //registering Toolbar component
-        PostGraphToolBarComponent toolBarComponent = new PostGraphToolBarComponent();
-        registerAllServices(bc, toolBarComponent, new Properties());
-		
+
+		//registering Toolbar component
+		PostGraphToolBarComponent toolBarComponent = new PostGraphToolBarComponent();
+		registerAllServices(bc, toolBarComponent, new Properties());
+
+		CyGraphSpaceResultPanel resultPanel = new CyGraphSpaceResultPanel("CyGraphSpace taskbar");
+		registerAllServices(context, resultPanel, new Properties());
+
 		//registering openBrowser for opening graph in GraphSpace
 		OpenBrowser openBrowser = getService(context, OpenBrowser.class);
-	    GetGraphsPanel getGraphsPanel = new GetGraphsPanel(taskManager, openBrowser);
-	    registerAllServices(context, getGraphsPanel, new Properties());
-    }
+		GetGraphsPanel getGraphsPanel = new GetGraphsPanel(taskManager, openBrowser);
+		registerAllServices(context, getGraphsPanel, new Properties());
+	}
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyActivator.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyActivator.java
@@ -78,7 +78,7 @@ public class CyActivator extends AbstractCyActivator {
 		manager.setCyRootNetworkManager(cyRootNetworkManager);
 
 		//register result panel
-		CyGraphSpaceResultPanel resultPanel = new CyGraphSpaceResultPanel("CyGraphSpace taskbar");
+		CyGraphSpaceResultPanel resultPanel = new CyGraphSpaceResultPanel(MessageConfig.RESULT_PANEL_TITLE);
 		registerAllServices(context, resultPanel, new Properties());
 
 	    //registering Toolbar component

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyActivator.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyActivator.java
@@ -44,11 +44,6 @@ public class CyActivator extends AbstractCyActivator {
 		Properties properties = null;
 		BundleContext bc = context;
 
-		//register Post Graph Action
-		action = new CyGraphSpaceMenuAction(MessageConfig.MenuActionTitle);
-		properties = new Properties();
-		registerService(context, action, CyAction.class, properties);
-
 		//getting cytoscape services
 		CyApplicationConfiguration config = getService(context,CyApplicationConfiguration.class);
 		CySwingAppAdapter appAdapter = getService(context, CySwingAppAdapter.class);
@@ -82,13 +77,19 @@ public class CyActivator extends AbstractCyActivator {
 		manager.setCyNetworkManager(cyNetworkManager);
 		manager.setCyRootNetworkManager(cyRootNetworkManager);
 
-		//registering Toolbar component
-		PostGraphToolBarComponent toolBarComponent = new PostGraphToolBarComponent();
-		registerAllServices(bc, toolBarComponent, new Properties());
-
+		//register result panel
 		CyGraphSpaceResultPanel resultPanel = new CyGraphSpaceResultPanel("CyGraphSpace taskbar");
 		registerAllServices(context, resultPanel, new Properties());
 
+	    //registering Toolbar component
+        PostGraphToolBarComponent toolBarComponent = new PostGraphToolBarComponent(resultPanel);
+        registerAllServices(bc, toolBarComponent, new Properties());
+
+        //register Post Graph Action
+        action = new CyGraphSpaceMenuAction(MessageConfig.MenuActionTitle, resultPanel);
+        properties = new Properties();
+        registerService(context, action, CyAction.class, properties);
+        
 		//registering openBrowser for opening graph in GraphSpace
 		OpenBrowser openBrowser = getService(context, OpenBrowser.class);
 		GetGraphsPanel getGraphsPanel = new GetGraphsPanel(taskManager, openBrowser);

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyGraphSpaceMenuAction.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/CyGraphSpaceMenuAction.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import javax.swing.event.MenuEvent;
 
 import org.cytoscape.application.swing.AbstractCyAction;
+import org.cytoscape.graphspace.cygraphspace.internal.gui.CyGraphSpaceResultPanel;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.CyObjectManager;
 
 public class CyGraphSpaceMenuAction extends AbstractCyAction {
@@ -12,14 +13,13 @@ public class CyGraphSpaceMenuAction extends AbstractCyAction {
     private static final long serialVersionUID = 1L;
     private PostGraphMenuActionListener actionListener;
 
-    public CyGraphSpaceMenuAction(String menuTitle) {
-
+    public CyGraphSpaceMenuAction(String menuTitle, CyGraphSpaceResultPanel resultPanel) {
         super(menuTitle, CyObjectManager.INSTANCE.getApplicationManager(), null, null);
 
         // Menu under File>Export
         setPreferredMenu("File.Export");
 
-        actionListener = new PostGraphMenuActionListener();
+        actionListener = new PostGraphMenuActionListener(resultPanel);
     }
 
     @Override

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/PostGraphMenuActionListener.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/PostGraphMenuActionListener.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 import org.cytoscape.graphspace.cygraphspace.internal.gui.AuthenticationDialog;
+import org.cytoscape.graphspace.cygraphspace.internal.gui.CyGraphSpaceResultPanel;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.CyObjectManager;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
 import org.cytoscape.graphspace.cygraphspace.internal.util.MessageConfig;
@@ -22,8 +23,12 @@ public class PostGraphMenuActionListener implements ActionListener {
     private static ImageIcon loading;
     private static JLabel loadingLabel;
     private static AuthenticationDialog dialog;
+    private CyGraphSpaceResultPanel resultPanel;
 
-    public PostGraphMenuActionListener() {
+    public PostGraphMenuActionListener(CyGraphSpaceResultPanel resultPanel) {
+
+        this.resultPanel = resultPanel;
+
         loadingFrame = new JFrame("Checking if the graph already exists");
         loading = new ImageIcon(this.getClass().getClassLoader().getResource("loading.gif"));
         loadingLabel = new JLabel("", loading, JLabel.CENTER);
@@ -59,7 +64,7 @@ public class PostGraphMenuActionListener implements ActionListener {
             new Thread() {
                 public void run() {
                     try {
-                        PostGraphExportUtils.populate(CyObjectManager.INSTANCE.getApplicationFrame(), loadingFrame);
+                        PostGraphExportUtils.populate(CyObjectManager.INSTANCE.getApplicationFrame(), loadingFrame, resultPanel);
                     } catch (Exception e) {
                         // TODO Auto-generated catch block
                         e.printStackTrace();
@@ -71,7 +76,7 @@ public class PostGraphMenuActionListener implements ActionListener {
         //if there is a network but the user is not authenticated, open the login dialog for the user to log in. Once logged in, open the post graph dialog
         else {
             if (dialog == null)
-                dialog = new AuthenticationDialog(loadingFrame);
+                dialog = new AuthenticationDialog(loadingFrame, resultPanel);
 
             dialog.setLocationRelativeTo(CyObjectManager.INSTANCE.getApplicationFrame());
             dialog.setVisible(true);

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/AuthenticationDialog.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/AuthenticationDialog.java
@@ -43,9 +43,14 @@ public class AuthenticationDialog extends JDialog {
 	private JButton loginButton;
 	JButton cancelButton;
 	private JFrame loadingFrame;
+	
+	private CyGraphSpaceResultPanel resultPanel;
 
-	public AuthenticationDialog(JFrame loadingFrame) {
+	public AuthenticationDialog(JFrame loadingFrame, CyGraphSpaceResultPanel resultPanel) {
 	    super(CyObjectManager.INSTANCE.getApplicationFrame(), "Log in to the Server", ModalityType.APPLICATION_MODAL);
+
+	    this.resultPanel = resultPanel;
+
 	    JLabel hostLabel = new JLabel("Host");
 
 	    AuthTextFieldListener textFieldListener = new AuthTextFieldListener();
@@ -184,7 +189,7 @@ public class AuthenticationDialog extends JDialog {
             new Thread() {
                 public void run() {
                     try {
-                        PostGraphExportUtils.populate(CyObjectManager.INSTANCE.getApplicationFrame(), loadingFrame);
+                        PostGraphExportUtils.populate(CyObjectManager.INSTANCE.getApplicationFrame(), loadingFrame, resultPanel);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -130,7 +130,9 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
         private JLabel statusLabel;
         private JLabel statusText;
 
-        private JButton urlBtn;
+        private JPanel linkPanel;
+        private JLabel linkLabel;
+        private JButton linkBtn;
 
         public PanelItem(int index, String name, String status) {
             this.index = index;
@@ -163,10 +165,6 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
             statusPanel = new JPanel(new FlowLayout(FlowLayout.LEFT)); 
             statusPanel.add(statusLabel);
             statusPanel.add(statusText);
-
-            urlBtn = new JButton("Link");
-            urlBtn.setVisible(false);
-            statusPanel.add(urlBtn);
             this.add(statusPanel);
         }
 
@@ -175,8 +173,12 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
             statusText.setText(status);
 
             if (graphId != -1) {
-                urlBtn.setVisible(true);
-                urlBtn.addActionListener(new ActionListener() {
+                linkBtn = new JButton(MessageConfig.GRAPHSPACE_LINK + graphId);
+                linkBtn.setOpaque(false);
+                linkBtn.setContentAreaFilled(false);
+                linkBtn.setBorderPainted(false);
+
+                linkBtn.addActionListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         try {
@@ -190,6 +192,12 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
                         }
                     }
                 });
+
+                linkLabel = new JLabel("Link: ");
+                linkPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+                linkPanel.add(linkLabel);
+                linkPanel.add(linkBtn);
+                this.add(linkPanel);
             }
         }
     }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -5,10 +5,17 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.Icon;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -19,6 +26,7 @@ import org.cytoscape.application.swing.CytoPanelComponent;
 import org.cytoscape.application.swing.CytoPanelName;
 import org.cytoscape.application.swing.CytoPanelState;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.CyObjectManager;
+import org.cytoscape.graphspace.cygraphspace.internal.util.MessageConfig;
 
 @SuppressWarnings("serial")
 public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponent, ResultPanelEventListener {
@@ -92,7 +100,7 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
 
     @Override
     public void updateGraphStatusEvent(ResultPanelEvent e) {
-        itemMap.get(e.getGraphIndex()).updateStatus(e.getGraphStatus());
+        itemMap.get(e.getGraphIndex()).updateStatus(e.getGraphStatus(), e.getGraphId());
         validate();
         repaint();
         showPanel();
@@ -115,6 +123,7 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
         private JLabel taskLabel;
         private JLabel graphNameLabel;
         private JLabel statusLabel;
+        private JButton urlBtn;
 
         public PanelItem(int index, String name, String status) {
             this.index = index;
@@ -134,9 +143,29 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
             this.setBorder(new MatteBorder(0, 0, 1, 0, Color.GRAY));
         }
 
-        public void updateStatus(String status) {
+        public void updateStatus(String status, int graphId) {
             this.status = status;
             statusLabel.setText("Status: " + status);
+
+            if (graphId != -1) {
+                urlBtn = new JButton("Link");
+                urlBtn.addActionListener(new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        try {
+                            java.awt.Desktop.getDesktop().browse(new URI(MessageConfig.GRAPHSPACE_LINK + graphId));
+                        } catch (IOException e1) {
+                            // TODO Auto-generated catch block
+                            e1.printStackTrace();
+                        } catch (URISyntaxException e1) {
+                            // TODO Auto-generated catch block
+                            e1.printStackTrace();
+                        }
+                    }
+                });
+
+                this.add(urlBtn);
+            }
         }
     }
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -20,86 +20,108 @@ import org.cytoscape.application.swing.CytoPanelName;
 @SuppressWarnings("serial")
 public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponent, ResultPanelEventListener {
 
-	private String title;
-	private JPanel mainList;
-	private int count;
-	private Map<Integer, PanelItem> map;
+    private String title;
+    private JPanel mainList;
+    private int itemCount;
+    private Map<Integer, PanelItem> itemMap;
 
-	public CyGraphSpaceResultPanel(String title) {
-		this.title = title;
-		this.count = 0;
-		this.map = new HashMap<>();
-		initializePanel();
-	}
+    public CyGraphSpaceResultPanel(String title) {
+        this.title = title;
+        this.itemCount = 1;
+        this.itemMap = new HashMap<>();
+        initializePanel();
+    }
 
-	private void initializePanel() {
-		setLayout(new BorderLayout());
+    private void initializePanel() {
+        setLayout(new BorderLayout());
 
-		// based on https://stackoverflow.com/questions/14615888/list-of-jpanels-that-eventually-uses-a-scrollbar
-		this.mainList = new JPanel(new GridBagLayout());
-		GridBagConstraints gbc = new GridBagConstraints();
-		gbc.gridwidth = GridBagConstraints.REMAINDER;
-		gbc.weightx = 1;
-		gbc.weighty = 1;
-		mainList.add(new JPanel(), gbc);
+        // based on https://stackoverflow.com/questions/14615888/list-of-jpanels-that-eventually-uses-a-scrollbar
+        this.mainList = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridwidth = GridBagConstraints.REMAINDER;
+        gbc.weightx = 1;
+        gbc.weighty = 1;
+        mainList.add(new JPanel(), gbc);
 
-		add(new JScrollPane(mainList));
-	}
+        add(new JScrollPane(mainList));
+    }
 
-	@Override
-	public Component getComponent() {
-		return this;
-	}
+    @Override
+    public Component getComponent() {
+        return this;
+    }
 
-	@Override
-	public CytoPanelName getCytoPanelName() {
-		return CytoPanelName.EAST;
-	}
+    @Override
+    public CytoPanelName getCytoPanelName() {
+        return CytoPanelName.EAST;
+    }
 
-	@Override
-	public Icon getIcon() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Icon getIcon() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public String getTitle() {
-		return title;
-	}
+    @Override
+    public String getTitle() {
+        return title;
+    }
 
-	private class PanelItem extends JPanel {
-		private int index;
-		private String name;
-		private String status;
 
-		public PanelItem(int index, String name, String status) {
-			this.index = index;
-			this.name = name;
-			this.status = status;
-			initPanelItem();
-		}
+    @Override
+    public int postGraphEvent(ResultPanelEvent e) {
+        PanelItem item = new PanelItem(itemCount, e.getGraphName(), e.getGraphStatus());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridwidth = GridBagConstraints.REMAINDER;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainList.add(item, gbc, 0);
 
-		private void initPanelItem() {
-			this.add(new JLabel(name));
-			this.setBorder(new MatteBorder(0, 0, 1, 0, Color.GRAY));
-		}
-	}
+        itemMap.put(itemCount, item);
 
-	@Override
-	public void postGraphEvent() {
-		PanelItem item = new PanelItem(count, "test", "test");
-		GridBagConstraints gbc = new GridBagConstraints();
-		gbc.gridwidth = GridBagConstraints.REMAINDER;
-		gbc.weightx = 1;
-		gbc.fill = GridBagConstraints.HORIZONTAL;
-		mainList.add(item, gbc, 0);
+        validate();
+        repaint();
 
-		validate();
-		repaint();
-	}
+        return itemCount++;
+    }
 
-	@Override
-	public void updateGraphEvent() {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void updateGraphStatusEvent(ResultPanelEvent e) {
+        itemMap.get(e.getGraphIndex()).updateStatus(e.getGraphStatus());
+        validate();
+        repaint();
+    }
+
+    private class PanelItem extends JPanel {
+        private int index;
+        private String name;
+        private String status;
+
+        private JLabel taskLabel;
+        private JLabel graphNameLabel;
+        private JLabel statusLabel;
+
+        public PanelItem(int index, String name, String status) {
+            this.index = index;
+            this.name = name;
+            this.status = status;
+            initPanelItem();
+        }
+
+        private void initPanelItem() {
+            taskLabel = new JLabel("Task: " + index);
+            graphNameLabel = new JLabel("Graph: " + name);
+            statusLabel = new JLabel("Status: " + status);
+
+            this.add(taskLabel);
+            this.add(graphNameLabel);
+            this.add(statusLabel);
+            this.setBorder(new MatteBorder(0, 0, 1, 0, Color.GRAY));
+        }
+
+        public void updateStatus(String status) {
+            this.status = status;
+            statusLabel.setText("Status: " + status);
+        }
+    }
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -173,7 +173,7 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
             statusText.setText(status);
 
             if (graphId != -1) {
-                linkBtn = new JButton(MessageConfig.GRAPHSPACE_LINK + graphId);
+                linkBtn = new JButton("<HTML><FONT color=\"#000099\"><U>" + MessageConfig.GRAPHSPACE_LINK + graphId + "</U></FONT></HTML>");
                 linkBtn.setOpaque(false);
                 linkBtn.setContentAreaFilled(false);
                 linkBtn.setBorderPainted(false);

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -1,9 +1,13 @@
 package org.cytoscape.graphspace.cygraphspace.internal.gui;
 
+import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 
 import javax.swing.Icon;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 
 import org.cytoscape.application.swing.CytoPanelComponent;
 import org.cytoscape.application.swing.CytoPanelName;
@@ -12,9 +16,25 @@ import org.cytoscape.application.swing.CytoPanelName;
 public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponent {
 
 	private String title;
+	private JPanel mainList;
 
 	public CyGraphSpaceResultPanel(String title) {
 		this.title = title;
+		initializePanel();
+	}
+
+	private void initializePanel() {
+		setLayout(new BorderLayout());
+
+		// based on https://stackoverflow.com/questions/14615888/list-of-jpanels-that-eventually-uses-a-scrollbar
+		this.mainList = new JPanel(new GridBagLayout());
+		GridBagConstraints gbc = new GridBagConstraints();
+		gbc.gridwidth = GridBagConstraints.REMAINDER;
+		gbc.weightx = 1;
+		gbc.weighty = 1;
+		mainList.add(new JPanel(), gbc);
+
+		add(new JScrollPane(mainList));
 	}
 
 	@Override

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -148,6 +148,7 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
             graphNameLabel = new JLabel("Graph: ");
 
             graphNameText = new JTextField(name);
+            graphNameText.setBorder(javax.swing.BorderFactory.createEmptyBorder());
             graphNameText.setEditable(false);
             graphNameText.setOpaque(false);
 

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -1,8 +1,8 @@
 package org.cytoscape.graphspace.cygraphspace.internal.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Component;
+import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
@@ -10,16 +10,18 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.border.MatteBorder;
+import javax.swing.JTextField;
+import javax.swing.border.TitledBorder;
 
 import org.cytoscape.application.swing.CytoPanel;
 import org.cytoscape.application.swing.CytoPanelComponent;
@@ -81,7 +83,7 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
     }
 
     @Override
-    public int postGraphEvent(ResultPanelEvent e) {
+    public int graphSpaceEvent(ResultPanelEvent e) {
         PanelItem item = new PanelItem(itemCount, e.getGraphName(), e.getGraphStatus());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridwidth = GridBagConstraints.REMAINDER;
@@ -120,9 +122,14 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
         private String name;
         private String status;
 
-        private JLabel taskLabel;
+        private JPanel graphPanel;
         private JLabel graphNameLabel;
+        private JTextField graphNameText;
+
+        private JPanel statusPanel;
         private JLabel statusLabel;
+        private JLabel statusText;
+
         private JButton urlBtn;
 
         public PanelItem(int index, String name, String status) {
@@ -133,22 +140,41 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
         }
 
         private void initPanelItem() {
-            taskLabel = new JLabel("Task: " + index);
-            graphNameLabel = new JLabel("Graph: " + name);
-            statusLabel = new JLabel("Status: " + status);
+            this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
-            this.add(taskLabel);
-            this.add(graphNameLabel);
-            this.add(statusLabel);
-            this.setBorder(new MatteBorder(0, 0, 1, 0, Color.GRAY));
+            TitledBorder taskBorder = BorderFactory.createTitledBorder("Task " + index);
+            this.setBorder(taskBorder);
+
+            graphNameLabel = new JLabel("Graph: ");
+
+            graphNameText = new JTextField(name);
+            graphNameText.setEditable(false);
+            graphNameText.setOpaque(false);
+
+            graphPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+            graphPanel.add(graphNameLabel);
+            graphPanel.add(graphNameText);
+            this.add(graphPanel);
+
+            statusLabel = new JLabel("Status: ");
+            statusText = new JLabel(status);
+
+            statusPanel = new JPanel(new FlowLayout(FlowLayout.LEFT)); 
+            statusPanel.add(statusLabel);
+            statusPanel.add(statusText);
+
+            urlBtn = new JButton("Link");
+            urlBtn.setVisible(false);
+            statusPanel.add(urlBtn);
+            this.add(statusPanel);
         }
 
         public void updateStatus(String status, int graphId) {
             this.status = status;
-            statusLabel.setText("Status: " + status);
+            statusText.setText(status);
 
             if (graphId != -1) {
-                urlBtn = new JButton("Link");
+                urlBtn.setVisible(true);
                 urlBtn.addActionListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
@@ -163,8 +189,6 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
                         }
                     }
                 });
-
-                this.add(urlBtn);
             }
         }
     }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -14,8 +14,11 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.border.MatteBorder;
 
+import org.cytoscape.application.swing.CytoPanel;
 import org.cytoscape.application.swing.CytoPanelComponent;
 import org.cytoscape.application.swing.CytoPanelName;
+import org.cytoscape.application.swing.CytoPanelState;
+import org.cytoscape.graphspace.cygraphspace.internal.singletons.CyObjectManager;
 
 @SuppressWarnings("serial")
 public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponent, ResultPanelEventListener {
@@ -24,11 +27,13 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
     private JPanel mainList;
     private int itemCount;
     private Map<Integer, PanelItem> itemMap;
+    private CytoPanel cytoPanel;
 
     public CyGraphSpaceResultPanel(String title) {
         this.title = title;
         this.itemCount = 1;
         this.itemMap = new HashMap<>();
+        this.cytoPanel = CyObjectManager.INSTANCE.getCySwingApplition().getCytoPanel(getCytoPanelName());
         initializePanel();
     }
 
@@ -67,7 +72,6 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
         return title;
     }
 
-
     @Override
     public int postGraphEvent(ResultPanelEvent e) {
         PanelItem item = new PanelItem(itemCount, e.getGraphName(), e.getGraphStatus());
@@ -81,6 +85,7 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
 
         validate();
         repaint();
+        showPanel();
 
         return itemCount++;
     }
@@ -90,6 +95,16 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
         itemMap.get(e.getGraphIndex()).updateStatus(e.getGraphStatus());
         validate();
         repaint();
+        showPanel();
+    }
+
+    private void showPanel() {
+        if (cytoPanel.getState() == CytoPanelState.HIDE)
+            cytoPanel.setState(CytoPanelState.DOCK);
+
+        // set visible and selected
+        this.setVisible(true);
+        cytoPanel.setSelectedIndex(cytoPanel.indexOfComponent(this.getComponent()));
     }
 
     private class PanelItem extends JPanel {

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -1,25 +1,34 @@
 package org.cytoscape.graphspace.cygraphspace.internal.gui;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.swing.Icon;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.border.MatteBorder;
 
 import org.cytoscape.application.swing.CytoPanelComponent;
 import org.cytoscape.application.swing.CytoPanelName;
 
 @SuppressWarnings("serial")
-public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponent {
+public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponent, ResultPanelEventListener {
 
 	private String title;
 	private JPanel mainList;
+	private int count;
+	private Map<Integer, PanelItem> map;
 
 	public CyGraphSpaceResultPanel(String title) {
 		this.title = title;
+		this.count = 0;
+		this.map = new HashMap<>();
 		initializePanel();
 	}
 
@@ -56,5 +65,41 @@ public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponen
 	@Override
 	public String getTitle() {
 		return title;
+	}
+
+	private class PanelItem extends JPanel {
+		private int index;
+		private String name;
+		private String status;
+
+		public PanelItem(int index, String name, String status) {
+			this.index = index;
+			this.name = name;
+			this.status = status;
+			initPanelItem();
+		}
+
+		private void initPanelItem() {
+			this.add(new JLabel(name));
+			this.setBorder(new MatteBorder(0, 0, 1, 0, Color.GRAY));
+		}
+	}
+
+	@Override
+	public void postGraphEvent() {
+		PanelItem item = new PanelItem(count, "test", "test");
+		GridBagConstraints gbc = new GridBagConstraints();
+		gbc.gridwidth = GridBagConstraints.REMAINDER;
+		gbc.weightx = 1;
+		gbc.fill = GridBagConstraints.HORIZONTAL;
+		mainList.add(item, gbc, 0);
+
+		validate();
+		repaint();
+	}
+
+	@Override
+	public void updateGraphEvent() {
+		// TODO Auto-generated method stub
 	}
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/CyGraphSpaceResultPanel.java
@@ -1,0 +1,40 @@
+package org.cytoscape.graphspace.cygraphspace.internal.gui;
+
+import java.awt.Component;
+
+import javax.swing.Icon;
+import javax.swing.JPanel;
+
+import org.cytoscape.application.swing.CytoPanelComponent;
+import org.cytoscape.application.swing.CytoPanelName;
+
+@SuppressWarnings("serial")
+public class CyGraphSpaceResultPanel extends JPanel implements CytoPanelComponent {
+
+	private String title;
+
+	public CyGraphSpaceResultPanel(String title) {
+		this.title = title;
+	}
+
+	@Override
+	public Component getComponent() {
+		return this;
+	}
+
+	@Override
+	public CytoPanelName getCytoPanelName() {
+		return CytoPanelName.EAST;
+	}
+
+	@Override
+	public Icon getIcon() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getTitle() {
+		return title;
+	}
+}

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/PostGraphDialog.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/PostGraphDialog.java
@@ -39,15 +39,15 @@ public class PostGraphDialog extends JDialog {
 	private GroupLayout groupLayout;
 	private JLabel graphNameLabel;
 	private JLabel graphNameValue;
-	
+
 	private CyGraphSpaceResultPanel resultPanel;
 
 	public PostGraphDialog(String graphName, JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tags,
 			CyGraphSpaceResultPanel resultPanel) {
 	    super(CyObjectManager.INSTANCE.getApplicationFrame(), "Upload the graph/netork GraphSpace", ModalityType.APPLICATION_MODAL);
-	    
+
 	    this.resultPanel = resultPanel;
-	    
+
 		JLabel hostLabel = new JLabel("Host:");
 		hostValueLabel = new JLabel("www.graphspace.org");
 		usernameValueLabel = new JLabel("Anonymous");

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/PostGraphDialog.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/PostGraphDialog.java
@@ -39,9 +39,15 @@ public class PostGraphDialog extends JDialog {
 	private GroupLayout groupLayout;
 	private JLabel graphNameLabel;
 	private JLabel graphNameValue;
+	
+	private CyGraphSpaceResultPanel resultPanel;
 
-	public PostGraphDialog(String graphName, JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tags) {
+	public PostGraphDialog(String graphName, JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tags,
+			CyGraphSpaceResultPanel resultPanel) {
 	    super(CyObjectManager.INSTANCE.getApplicationFrame(), "Upload the graph/netork GraphSpace", ModalityType.APPLICATION_MODAL);
+	    
+	    this.resultPanel = resultPanel;
+	    
 		JLabel hostLabel = new JLabel("Host:");
 		hostValueLabel = new JLabel("www.graphspace.org");
 		usernameValueLabel = new JLabel("Anonymous");
@@ -127,6 +133,7 @@ public class PostGraphDialog extends JDialog {
         this.dispose();
         SynchronousTaskManager<?> synTaskMan = CyObjectManager.INSTANCE.getSynchrounousTaskManager();
         PostGraphTask postGraphTask = new PostGraphTask(graphJSON, styleJSON, isGraphPublic);
+        postGraphTask.setResultPanelEventListener(resultPanel);
         synTaskMan.execute(new TaskIterator(postGraphTask));
 	}
 

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/PostGraphToolBarComponent.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/PostGraphToolBarComponent.java
@@ -20,8 +20,8 @@ public class PostGraphToolBarComponent extends AbstractToolBarComponent implemen
 
     private JButton button;
     private PostGraphMenuActionListener actionListener;
-
-	public PostGraphToolBarComponent() {
+    
+	public PostGraphToolBarComponent(CyGraphSpaceResultPanel resultPanel) {
 		super();
 		button = new JButton();
 
@@ -36,7 +36,7 @@ public class PostGraphToolBarComponent extends AbstractToolBarComponent implemen
 		button.setEnabled(false);
 		
 		//action attached to the button
-		actionListener = new PostGraphMenuActionListener();
+		actionListener = new PostGraphMenuActionListener(resultPanel);
 		button.addActionListener(actionListener);
 	}
 		

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEvent.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEvent.java
@@ -3,28 +3,36 @@ package org.cytoscape.graphspace.cygraphspace.internal.gui;
 public class ResultPanelEvent {
 
     private int graphIndex;
+    private int graphId;
     private String graphName;
     private String graphStatus;
 
     public ResultPanelEvent(String graphName, String graphStatus) {
         this.graphIndex = -1;
+        this.graphId = -1;
         this.graphName = graphName;
         this.graphStatus = graphStatus;
     }
-    
-    public ResultPanelEvent(int graphIndex, String graphName, String graphStatus) {
+
+    public ResultPanelEvent(int graphIndex, int graphId, String graphName, String graphStatus) {
         this.graphIndex = graphIndex;
+        this.graphId = graphId;
         this.graphName = graphName;
         this.graphStatus = graphStatus;
     }
-    
+
     public int getGraphIndex() {
         return this.graphIndex;
+    }
+
+    public int getGraphId() {
+        return this.graphId;
     }
 
     public String getGraphName() {
         return this.graphName;
     }
+
 
     public String getGraphStatus() {
         return this.graphStatus;

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEvent.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEvent.java
@@ -1,0 +1,32 @@
+package org.cytoscape.graphspace.cygraphspace.internal.gui;
+
+public class ResultPanelEvent {
+
+    private int graphIndex;
+    private String graphName;
+    private String graphStatus;
+
+    public ResultPanelEvent(String graphName, String graphStatus) {
+        this.graphIndex = -1;
+        this.graphName = graphName;
+        this.graphStatus = graphStatus;
+    }
+    
+    public ResultPanelEvent(int graphIndex, String graphName, String graphStatus) {
+        this.graphIndex = graphIndex;
+        this.graphName = graphName;
+        this.graphStatus = graphStatus;
+    }
+    
+    public int getGraphIndex() {
+        return this.graphIndex;
+    }
+
+    public String getGraphName() {
+        return this.graphName;
+    }
+
+    public String getGraphStatus() {
+        return this.graphStatus;
+    }
+}

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEventListener.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEventListener.java
@@ -1,0 +1,6 @@
+package org.cytoscape.graphspace.cygraphspace.internal.gui;
+
+public interface ResultPanelEventListener {
+	public void postGraphEvent();
+	public void updateGraphEvent();
+}

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEventListener.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEventListener.java
@@ -1,6 +1,6 @@
 package org.cytoscape.graphspace.cygraphspace.internal.gui;
 
 public interface ResultPanelEventListener {
-	public void postGraphEvent();
-	public void updateGraphEvent();
+    public int postGraphEvent(ResultPanelEvent e);
+    public void updateGraphStatusEvent(ResultPanelEvent e);
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEventListener.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/ResultPanelEventListener.java
@@ -1,6 +1,6 @@
 package org.cytoscape.graphspace.cygraphspace.internal.gui;
 
 public interface ResultPanelEventListener {
-    public int postGraphEvent(ResultPanelEvent e);
+    public int graphSpaceEvent(ResultPanelEvent e);
     public void updateGraphStatusEvent(ResultPanelEvent e);
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/UpdateGraphDialog.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/gui/UpdateGraphDialog.java
@@ -39,9 +39,15 @@ public class UpdateGraphDialog extends JDialog {
 	private JLabel graphNameValue;
 	private JLabel graphNameLabel;
     private JLabel updateMessage;
+
+    private CyGraphSpaceResultPanel resultPanel;
 	
-	public UpdateGraphDialog(String graphName, JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tags) {
+	public UpdateGraphDialog(String graphName, JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tags,
+	        CyGraphSpaceResultPanel resultPanel) {
 	    super(CyObjectManager.INSTANCE.getApplicationFrame(), "Update the graph/network on GraphSpace", ModalityType.APPLICATION_MODAL);
+
+	    this.resultPanel = resultPanel;
+
 		JLabel hostLabel = new JLabel("Host:");
 		hostValueLabel = new JLabel("www.graphspace.org");
 		usernameValueLabel = new JLabel("Anonymous");
@@ -136,6 +142,7 @@ public class UpdateGraphDialog extends JDialog {
         this.dispose();
         SynchronousTaskManager<?> synTaskMan = CyObjectManager.INSTANCE.getSynchrounousTaskManager();
         UpdateGraphTask updateGraphTask = new UpdateGraphTask(graphJSON, styleJSON, isPublic);
+        updateGraphTask.setResultPanelEventListener(resultPanel);
         synTaskMan.execute(new TaskIterator(updateGraphTask));
 	}
 	

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/singletons/Server.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/singletons/Server.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.graphspace.javaclient.Graph;
 import org.graphspace.javaclient.GraphSpaceClient;
+import org.graphspace.javaclient.Response;
 import org.json.JSONObject;
 
 /**
@@ -112,8 +113,8 @@ public enum Server{
 	}
 	
 	//post a graph to GraphSpace
-	public void postGraph(JSONObject graphJson, JSONObject styleJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
-		client.postGraph(graphJson, styleJson, isGraphPublic, tagsList);
+	public Response postGraph(JSONObject graphJson, JSONObject styleJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
+		return client.postGraph(graphJson, styleJson, isGraphPublic, tagsList);
 	}
 	
 	//check if a graph to be exported can be updated

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/singletons/Server.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/singletons/Server.java
@@ -107,9 +107,9 @@ public enum Server{
 	}
 	
 	//update an existing graph on GraphSpace
-	public void updateGraph(String name, JSONObject graphJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
+	public Response updateGraph(String name, JSONObject graphJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
 		Graph graph = client.getGraph(name, this.username);
-		client.updateGraph(name, graphJson, graph.getStyleJson(), isGraphPublic, tagsList);
+		return client.updateGraph(name, graphJson, graph.getStyleJson(), isGraphPublic, tagsList);
 	}
 	
 	//post a graph to GraphSpace

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
@@ -50,7 +50,7 @@ public class PostGraphTask extends AbstractTask {
 
         try {
             if (listener != null)
-                panelIndex = listener.postGraphEvent(
+                panelIndex = listener.graphSpaceEvent(
                         new ResultPanelEvent(graphJSON.getJSONObject("data").getString("name"),MessageConfig.TASK_IN_PROGRESS));
 
             graphId = postGraph(graphJSON, styleJSON, isGraphPublic, null).getGraph().getId();

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import javax.swing.JOptionPane;
 
+import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEvent;
 import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEventListener;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
 import org.cytoscape.graphspace.cygraphspace.internal.util.MessageConfig;
@@ -15,56 +16,70 @@ import org.json.JSONObject;
  * Task class that posts graph to the GraphSpace and update related status
  */
 public class PostGraphTask extends AbstractTask {
-	private JSONObject graphJSON;
-	private JSONObject styleJSON; 
-	private boolean isGraphPublic;
-	private TaskMonitor taskMonitor;
-	private ResultPanelEventListener listener;
+    private JSONObject graphJSON;
+    private JSONObject styleJSON; 
+    private boolean isGraphPublic;
+    private TaskMonitor taskMonitor;
+    private ResultPanelEventListener listener;
 
-	public PostGraphTask(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic) {
-		this.graphJSON = graphJSON;
-		this.styleJSON = styleJSON;
-		this.isGraphPublic = isGraphPublic;
-	}
+    public PostGraphTask(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic) {
+        this.graphJSON = graphJSON;
+        this.styleJSON = styleJSON;
+        this.isGraphPublic = isGraphPublic;
+        this.listener = null;
+    }
 
-	@Override
-	public void run(TaskMonitor taskMonitor) throws Exception {
+    @Override
+    public void run(TaskMonitor taskMonitor) throws Exception {
 
-		this.taskMonitor = taskMonitor;
-		taskMonitor.setTitle(MessageConfig.POST_GRAPH_TASK_TITLE);
-		taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_IN_PROGRESS);
+        this.taskMonitor = taskMonitor;
+        taskMonitor.setTitle(MessageConfig.POST_GRAPH_TASK_TITLE);
+        taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_IN_PROGRESS);
 
-		// run task in background
-		new Thread() {
-			public void run() {
-				postGraph();
-			}
-		}.start();
-	}
+        // run task in background
+        new Thread() {
+            public void run() {
+                postGraph();
+            }
+        }.start();
+    }
 
-	private void postGraph() {
-		try {
-			postGraph(graphJSON, styleJSON, isGraphPublic, null);
-		} catch (Exception e1) {
-			taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_FAIL);
-			JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_FAIL, 
-					"Error", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-		if (listener != null)
-			listener.postGraphEvent();
+    private void postGraph() {
+        int panelIndex = -1;
 
-		taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_SUCCESS);
-		JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_SUCCESS, 
-				"Message", JOptionPane.INFORMATION_MESSAGE);
-	}
+        try {
+            if (listener != null)
+                panelIndex = listener.postGraphEvent(
+                        new ResultPanelEvent(graphJSON.getJSONObject("data").getString("name"),MessageConfig.TASK_IN_PROGRESS));
 
-	//post the current network to GraphSpace
-	private void postGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
-		Server.INSTANCE.postGraph(graphJSON, styleJSON, isGraphPublic, tagsList);
-	}
+            postGraph(graphJSON, styleJSON, isGraphPublic, null);
+        } catch (Exception e1) {
+            taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_FAIL);
+            JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_FAIL, 
+                    "Error", JOptionPane.ERROR_MESSAGE);
 
-	public void setResultPanelEventListener(ResultPanelEventListener listener) {
-		this.listener = listener;
-	}
+            if (listener != null)
+                listener.updateGraphStatusEvent(
+                        new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_FAIL));
+
+            return;
+        }
+
+        if (listener != null)
+            listener.updateGraphStatusEvent(
+                    new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_COMPLETE));
+
+        taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_SUCCESS);
+        JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_SUCCESS, 
+                "Message", JOptionPane.INFORMATION_MESSAGE);
+    }
+
+    //post the current network to GraphSpace
+    private void postGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception {
+        Server.INSTANCE.postGraph(graphJSON, styleJSON, isGraphPublic, tagsList);
+    }
+
+    public void setResultPanelEventListener(ResultPanelEventListener listener) {
+        this.listener = listener;
+    }
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
@@ -10,6 +10,7 @@ import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
 import org.cytoscape.graphspace.cygraphspace.internal.util.MessageConfig;
 import org.cytoscape.work.AbstractTask;
 import org.cytoscape.work.TaskMonitor;
+import org.graphspace.javaclient.Response;
 import org.json.JSONObject;
 
 /**
@@ -45,14 +46,14 @@ public class PostGraphTask extends AbstractTask {
     }
 
     private void postGraph() {
-        int panelIndex = -1;
+        int panelIndex = -1,  graphId = -1;
 
         try {
             if (listener != null)
                 panelIndex = listener.postGraphEvent(
                         new ResultPanelEvent(graphJSON.getJSONObject("data").getString("name"),MessageConfig.TASK_IN_PROGRESS));
 
-            postGraph(graphJSON, styleJSON, isGraphPublic, null);
+            graphId = postGraph(graphJSON, styleJSON, isGraphPublic, null).getGraph().getId();
         } catch (Exception e1) {
             taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_FAIL);
             JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_FAIL, 
@@ -60,14 +61,14 @@ public class PostGraphTask extends AbstractTask {
 
             if (listener != null)
                 listener.updateGraphStatusEvent(
-                        new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_FAIL));
+                        new ResultPanelEvent(panelIndex, graphId, "", MessageConfig.TASK_FAIL));
 
             return;
         }
 
         if (listener != null)
             listener.updateGraphStatusEvent(
-                    new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_COMPLETE));
+                    new ResultPanelEvent(panelIndex, graphId, "", MessageConfig.TASK_COMPLETE));
 
         taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_SUCCESS);
         JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_SUCCESS, 
@@ -75,8 +76,8 @@ public class PostGraphTask extends AbstractTask {
     }
 
     //post the current network to GraphSpace
-    private void postGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception {
-        Server.INSTANCE.postGraph(graphJSON, styleJSON, isGraphPublic, tagsList);
+    private Response postGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception {
+        return Server.INSTANCE.postGraph(graphJSON, styleJSON, isGraphPublic, tagsList);
     }
 
     public void setResultPanelEventListener(ResultPanelEventListener listener) {

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
@@ -2,8 +2,6 @@ package org.cytoscape.graphspace.cygraphspace.internal.task;
 
 import java.util.ArrayList;
 
-import javax.swing.JOptionPane;
-
 import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEvent;
 import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEventListener;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
@@ -56,8 +54,6 @@ public class PostGraphTask extends AbstractTask {
             graphId = postGraph(graphJSON, styleJSON, isGraphPublic, null).getGraph().getId();
         } catch (Exception e1) {
             taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_FAIL);
-            JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_FAIL, 
-                    "Error", JOptionPane.ERROR_MESSAGE);
 
             if (listener != null)
                 listener.updateGraphStatusEvent(
@@ -71,8 +67,6 @@ public class PostGraphTask extends AbstractTask {
                     new ResultPanelEvent(panelIndex, graphId, "", MessageConfig.TASK_COMPLETE));
 
         taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_SUCCESS);
-        JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_SUCCESS, 
-                "Message", JOptionPane.INFORMATION_MESSAGE);
     }
 
     //post the current network to GraphSpace

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/PostGraphTask.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import javax.swing.JOptionPane;
 
+import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEventListener;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
 import org.cytoscape.graphspace.cygraphspace.internal.util.MessageConfig;
 import org.cytoscape.work.AbstractTask;
@@ -14,48 +15,56 @@ import org.json.JSONObject;
  * Task class that posts graph to the GraphSpace and update related status
  */
 public class PostGraphTask extends AbstractTask {
-    private JSONObject graphJSON;
-    private JSONObject styleJSON; 
-    private boolean isGraphPublic;
-    private TaskMonitor taskMonitor;
+	private JSONObject graphJSON;
+	private JSONObject styleJSON; 
+	private boolean isGraphPublic;
+	private TaskMonitor taskMonitor;
+	private ResultPanelEventListener listener;
 
-    public PostGraphTask(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic) {
-        this.graphJSON = graphJSON;
-        this.styleJSON = styleJSON;
-        this.isGraphPublic = isGraphPublic;
-    }
+	public PostGraphTask(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic) {
+		this.graphJSON = graphJSON;
+		this.styleJSON = styleJSON;
+		this.isGraphPublic = isGraphPublic;
+	}
 
-    @Override
-    public void run(TaskMonitor taskMonitor) throws Exception {
+	@Override
+	public void run(TaskMonitor taskMonitor) throws Exception {
 
-        this.taskMonitor = taskMonitor;
-        taskMonitor.setTitle(MessageConfig.POST_GRAPH_TASK_TITLE);
-        taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_IN_PROGRESS);
+		this.taskMonitor = taskMonitor;
+		taskMonitor.setTitle(MessageConfig.POST_GRAPH_TASK_TITLE);
+		taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_IN_PROGRESS);
 
-        // run task in background
-        new Thread() {
-            public void run() {
-                postGraph();
-            }
-        }.start();
-    }
+		// run task in background
+		new Thread() {
+			public void run() {
+				postGraph();
+			}
+		}.start();
+	}
 
-    private void postGraph() {
-        try {
-            postGraph(graphJSON, styleJSON, isGraphPublic, null);
-        } catch (Exception e1) {
-            taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_FAIL);
-            JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_FAIL, 
-                    "Error", JOptionPane.ERROR_MESSAGE);
-            return;
-        }
-        taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_SUCCESS);
-        JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_SUCCESS, 
-                "Message", JOptionPane.INFORMATION_MESSAGE);
-    }
+	private void postGraph() {
+		try {
+			postGraph(graphJSON, styleJSON, isGraphPublic, null);
+		} catch (Exception e1) {
+			taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_FAIL);
+			JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_FAIL, 
+					"Error", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+		if (listener != null)
+			listener.postGraphEvent();
 
-    //post the current network to GraphSpace
-    private void postGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
-        Server.INSTANCE.postGraph(graphJSON, styleJSON, isGraphPublic, tagsList);
-    }
+		taskMonitor.setStatusMessage(MessageConfig.POST_GRAPH_TASK_STATUS_SUCCESS);
+		JOptionPane.showMessageDialog(null, MessageConfig.POST_GRAPH_TASK_DIALOG_SUCCESS, 
+				"Message", JOptionPane.INFORMATION_MESSAGE);
+	}
+
+	//post the current network to GraphSpace
+	private void postGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
+		Server.INSTANCE.postGraph(graphJSON, styleJSON, isGraphPublic, tagsList);
+	}
+
+	public void setResultPanelEventListener(ResultPanelEventListener listener) {
+		this.listener = listener;
+	}
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
@@ -10,6 +10,7 @@ import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
 import org.cytoscape.graphspace.cygraphspace.internal.util.MessageConfig;
 import org.cytoscape.work.AbstractTask;
 import org.cytoscape.work.TaskMonitor;
+import org.graphspace.javaclient.Response;
 import org.json.JSONObject;
 
 /**
@@ -39,19 +40,19 @@ public class UpdateGraphTask extends AbstractTask {
         // run task in background
         new Thread() {
             public void run() {
-                postGraph();
+                updateGraph();
             }
         }.start();
     }
 
-    private void postGraph() {
+    private void updateGraph() {
         int panelIndex = -1, graphId = -1;
         try {
             if (listener != null)
-                panelIndex = listener.postGraphEvent(
+                panelIndex = listener.graphSpaceEvent(
                         new ResultPanelEvent(graphJSON.getJSONObject("data").getString("name"),MessageConfig.TASK_IN_PROGRESS));
 
-            updateGraph(graphJSON, styleJSON, isGraphPublic, null);
+            graphId = updateGraph(graphJSON, styleJSON, isGraphPublic, null).getGraph().getId();
         } catch (Exception e1) {
             taskMonitor.setStatusMessage(MessageConfig.UPDATE_GRAPH_TASK_STATUS_FAIL);
             JOptionPane.showMessageDialog(null, 
@@ -74,9 +75,9 @@ public class UpdateGraphTask extends AbstractTask {
     }
 
     //post the current network to GraphSpace
-    private void updateGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isPublic, ArrayList<String> tagsList) throws Exception{
+    private Response updateGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isPublic, ArrayList<String> tagsList) throws Exception{
         String name = graphJSON.getJSONObject("data").getString("name");
-        Server.INSTANCE.updateGraph(name, graphJSON, isPublic, tagsList);
+        return Server.INSTANCE.updateGraph(name, graphJSON, isPublic, tagsList);
     }
 
     public void setResultPanelEventListener(ResultPanelEventListener listener) {

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
@@ -2,8 +2,6 @@ package org.cytoscape.graphspace.cygraphspace.internal.task;
 
 import java.util.ArrayList;
 
-import javax.swing.JOptionPane;
-
 import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEvent;
 import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEventListener;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
@@ -55,8 +53,6 @@ public class UpdateGraphTask extends AbstractTask {
             graphId = updateGraph(graphJSON, styleJSON, isGraphPublic, null).getGraph().getId();
         } catch (Exception e1) {
             taskMonitor.setStatusMessage(MessageConfig.UPDATE_GRAPH_TASK_STATUS_FAIL);
-            JOptionPane.showMessageDialog(null, 
-                    MessageConfig.UPDATE_GRAPH_TASK_DIALOG_FAIL, "Error", JOptionPane.ERROR_MESSAGE);
 
             if (listener != null)
                 listener.updateGraphStatusEvent(
@@ -70,8 +66,6 @@ public class UpdateGraphTask extends AbstractTask {
                     new ResultPanelEvent(panelIndex, graphId, "", MessageConfig.TASK_COMPLETE));
 
         taskMonitor.setStatusMessage(MessageConfig.UPDATE_GRAPH_TASK_STATUS_SUCCESS);
-        JOptionPane.showMessageDialog(null, 
-                MessageConfig.UPDATE_GRAPH_TASK_DIALOG_SUCCESS, "Message", JOptionPane.INFORMATION_MESSAGE);
     }
 
     //post the current network to GraphSpace

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
@@ -45,7 +45,7 @@ public class UpdateGraphTask extends AbstractTask {
     }
 
     private void postGraph() {
-        int panelIndex = -1;
+        int panelIndex = -1, graphId = -1;
         try {
             if (listener != null)
                 panelIndex = listener.postGraphEvent(
@@ -59,14 +59,14 @@ public class UpdateGraphTask extends AbstractTask {
 
             if (listener != null)
                 listener.updateGraphStatusEvent(
-                        new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_FAIL));
+                        new ResultPanelEvent(panelIndex, graphId, "", MessageConfig.TASK_FAIL));
 
             return;
         }
 
         if (listener != null)
             listener.updateGraphStatusEvent(
-                    new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_COMPLETE));
+                    new ResultPanelEvent(panelIndex, graphId, "", MessageConfig.TASK_COMPLETE));
 
         taskMonitor.setStatusMessage(MessageConfig.UPDATE_GRAPH_TASK_STATUS_SUCCESS);
         JOptionPane.showMessageDialog(null, 

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/task/UpdateGraphTask.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 
 import javax.swing.JOptionPane;
 
+import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEvent;
+import org.cytoscape.graphspace.cygraphspace.internal.gui.ResultPanelEventListener;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.Server;
 import org.cytoscape.graphspace.cygraphspace.internal.util.MessageConfig;
 import org.cytoscape.work.AbstractTask;
@@ -14,16 +16,17 @@ import org.json.JSONObject;
  * Task class that update graph to the GraphSpace and update related status
  */
 public class UpdateGraphTask extends AbstractTask {
-
     private JSONObject graphJSON;
     private JSONObject styleJSON; 
     private boolean isGraphPublic;
     private TaskMonitor taskMonitor;
+    private ResultPanelEventListener listener;
 
     public UpdateGraphTask(JSONObject graphJSON, JSONObject styleJSON, boolean isGraphPublic) {
         this.graphJSON = graphJSON;
         this.styleJSON = styleJSON;
         this.isGraphPublic = isGraphPublic;
+        this.listener = null;
     }
 
     @Override
@@ -42,14 +45,29 @@ public class UpdateGraphTask extends AbstractTask {
     }
 
     private void postGraph() {
+        int panelIndex = -1;
         try {
+            if (listener != null)
+                panelIndex = listener.postGraphEvent(
+                        new ResultPanelEvent(graphJSON.getJSONObject("data").getString("name"),MessageConfig.TASK_IN_PROGRESS));
+
             updateGraph(graphJSON, styleJSON, isGraphPublic, null);
         } catch (Exception e1) {
             taskMonitor.setStatusMessage(MessageConfig.UPDATE_GRAPH_TASK_STATUS_FAIL);
             JOptionPane.showMessageDialog(null, 
                     MessageConfig.UPDATE_GRAPH_TASK_DIALOG_FAIL, "Error", JOptionPane.ERROR_MESSAGE);
+
+            if (listener != null)
+                listener.updateGraphStatusEvent(
+                        new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_FAIL));
+
             return;
         }
+
+        if (listener != null)
+            listener.updateGraphStatusEvent(
+                    new ResultPanelEvent(panelIndex, "", MessageConfig.TASK_COMPLETE));
+
         taskMonitor.setStatusMessage(MessageConfig.UPDATE_GRAPH_TASK_STATUS_SUCCESS);
         JOptionPane.showMessageDialog(null, 
                 MessageConfig.UPDATE_GRAPH_TASK_DIALOG_SUCCESS, "Message", JOptionPane.INFORMATION_MESSAGE);
@@ -59,5 +77,9 @@ public class UpdateGraphTask extends AbstractTask {
     private void updateGraph(JSONObject graphJSON, JSONObject styleJSON, boolean isPublic, ArrayList<String> tagsList) throws Exception{
         String name = graphJSON.getJSONObject("data").getString("name");
         Server.INSTANCE.updateGraph(name, graphJSON, isPublic, tagsList);
+    }
+
+    public void setResultPanelEventListener(ResultPanelEventListener listener) {
+        this.listener = listener;
     }
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
@@ -12,6 +12,9 @@ public class MessageConfig {
     public final static String APP_DESCRIPTION = "<html>" + "The CyGraphSpace App is used to upload graphs to "
             + "<a href=\"http://www.grapshace.org\">GraphSpace</a>. ";
 
+    // GraphSpace link
+    public final static String GRAPHSPACE_LINK = "http://graphspace.org/graphs/";
+
     // error messages related to authentication dialog
     public final static String AUTH_NOT_FILL_ERROR_MSG = "Please enter all the values.";
     public final static String AUTH_INVALID_URL = "IP address of the entered host could not be determined.\n"
@@ -43,7 +46,7 @@ public class MessageConfig {
     // Error message for event where user tries to upload large network
     public final static String NETWORK_TOO_LARGE_MSG = "Currently GraphSpace cannot handle networks with more than 400 nodes and/or 1000 edges.\n"
             + "Please select a smaller network or subnetwork to upload.";
-    
+
     // Result panel status messages
     public static final String TASK_COMPLETE = "Complete";
     public static final String TASK_IN_PROGRESS = "In progress";

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
@@ -43,4 +43,9 @@ public class MessageConfig {
     // Error message for event where user tries to upload large network
     public final static String NETWORK_TOO_LARGE_MSG = "Currently GraphSpace cannot handle networks with more than 400 nodes and/or 1000 edges.\n"
             + "Please select a smaller network or subnetwork to upload.";
+    
+    // Result panel status messages
+    public static final String TASK_COMPLETE = "Complete";
+    public static final String TASK_IN_PROGRESS = "In progress";
+    public static final String TASK_FAIL = "Fail";
 }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
@@ -40,7 +40,7 @@ public class MessageConfig {
             + "Please select a smaller network or subnetwork to upload.";
 
     // Result panel title
-    public static final String RESULT_PANEL_TITLE = "CyGraphSpace Task";
+    public static final String RESULT_PANEL_TITLE = "CyGraphSpace Status";
 
     // Result panel status messages
     public static final String TASK_COMPLETE = "Complete";

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/MessageConfig.java
@@ -29,23 +29,18 @@ public class MessageConfig {
     public final static String UPDATE_GRAPH_TASK_STATUS_FAIL = "CyGraphSpace failed to update the graph.";
     public final static String UPDATE_GRAPH_TASK_STATUS_SUCCESS = "CyGraphSpace updated the graph successfully.";
 
-    // Update graph task dialog message, shown in the pop up window after update graph task is done
-    public final static String UPDATE_GRAPH_TASK_DIALOG_SUCCESS = "You have updated the graph successfully.";
-    public final static String UPDATE_GRAPH_TASK_DIALOG_FAIL = "CyGraphSpace failed to update the graph.";
-
     // Post graph task status message, shown in the status bar of the Cytoscape
     public final static String POST_GRAPH_TASK_TITLE = "Upload Status";
     public final static String POST_GRAPH_TASK_STATUS_IN_PROGRESS = "Uploading graph to GraphSpace. Please wait...";
     public final static String POST_GRAPH_TASK_STATUS_FAIL = "CyGraphSpace failed to upload the graph.";
     public final static String POST_GRAPH_TASK_STATUS_SUCCESS = "CyGraphSpace uploaded the graph successfully.";
 
-    // Post graph task dialog message, shown in the pop up window after update graph task is done
-    public final static String POST_GRAPH_TASK_DIALOG_SUCCESS = "You have uploaded the graph successfully.";
-    public final static String POST_GRAPH_TASK_DIALOG_FAIL = "CyGraphSpace failed to upload the graph.";
-
     // Error message for event where user tries to upload large network
     public final static String NETWORK_TOO_LARGE_MSG = "Currently GraphSpace cannot handle networks with more than 400 nodes and/or 1000 edges.\n"
             + "Please select a smaller network or subnetwork to upload.";
+
+    // Result panel title
+    public static final String RESULT_PANEL_TITLE = "CyGraphSpace Task";
 
     // Result panel status messages
     public static final String TASK_COMPLETE = "Complete";

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/PostGraphExportUtils.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/PostGraphExportUtils.java
@@ -8,6 +8,7 @@ import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
 import org.apache.commons.io.FileUtils;
+import org.cytoscape.graphspace.cygraphspace.internal.gui.CyGraphSpaceResultPanel;
 import org.cytoscape.graphspace.cygraphspace.internal.gui.PostGraphDialog;
 import org.cytoscape.graphspace.cygraphspace.internal.gui.UpdateGraphDialog;
 import org.cytoscape.graphspace.cygraphspace.internal.singletons.CyObjectManager;
@@ -30,7 +31,7 @@ public class PostGraphExportUtils {
      * @param loadingFrame the loading frame
      * @throws Exception
      */
-    public static void populate(Frame parent, JFrame loadingFrame) throws Exception {
+    public static void populate(Frame parent, JFrame loadingFrame, CyGraphSpaceResultPanel resultPanel) throws Exception {
         JSONObject graphJSON = exportNetworkToJSON();
         JSONObject styleJSON = exportStyleToJSON();
         String graphName = graphJSON.getJSONObject("data").getString("name");
@@ -59,7 +60,7 @@ public class PostGraphExportUtils {
                 }
             });
 
-            PostGraphDialog postDialog = new PostGraphDialog(graphName, graphJSON, styleJSON, isGraphPublic, null);
+            PostGraphDialog postDialog = new PostGraphDialog(graphName, graphJSON, styleJSON, isGraphPublic, null, resultPanel);
             postDialog.setLocationRelativeTo(parent);
             postDialog.setVisible(true);
         }

--- a/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/PostGraphExportUtils.java
+++ b/CyGraphSpaceApp/src/main/java/org/cytoscape/graphspace/cygraphspace/internal/util/PostGraphExportUtils.java
@@ -47,7 +47,7 @@ public class PostGraphExportUtils {
 
             Graph graph = Server.INSTANCE.getGraphByName(graphName);
             isGraphPublic = graph.isPublic();
-            UpdateGraphDialog updateDialog = new UpdateGraphDialog(graphName, graphJSON, styleJSON, isGraphPublic, null);
+            UpdateGraphDialog updateDialog = new UpdateGraphDialog(graphName, graphJSON, styleJSON, isGraphPublic, null, resultPanel);
             updateDialog.setLocationRelativeTo(parent);
             updateDialog.setVisible(true);
         }

--- a/GraphSpaceJavaClient/.classpath
+++ b/GraphSpaceJavaClient/.classpath
@@ -12,8 +12,9 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/GraphSpaceJavaClient/.settings/org.eclipse.jdt.core.prefs
+++ b/GraphSpaceJavaClient/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,13 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.8

--- a/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/Graph.java
+++ b/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/Graph.java
@@ -366,7 +366,7 @@ public class Graph extends Resource {
      * @return response status on update request to GraphSpace
      * @throws Exception
      */
-    public String updateGraph() throws Exception{
+    public Response updateGraph() throws Exception{
     	if(this.graphJson == null) {
     		throw new GraphException(ExceptionCode.BAD_REQUEST_FORMAT, ExceptionMessage.BAD_REQUEST_FORMAT_EXCEPTION,
     				"Graph JSON is not set.");
@@ -394,8 +394,7 @@ public class Graph extends Resource {
     		int graphId = graphToBeUpdated.getId();
     		String path = Config.GRAPHS_PATH + graphId;
         	JSONObject jsonResponse = restClient.put(path, data);
-        	Response response = new Response(jsonResponse);
-        	return response.getResponseStatus();
+        	return new Response(jsonResponse);
     	}
     	throw new GraphException(ExceptionCode.GRAPH_NOT_FOUND_EXCEPTION, ExceptionMessage.GRAPH_NOT_FOUND_EXCEPTION,
     			"This graph is not currently uploaded on GraphSpace. Please export the graph to GraphSpace first.");
@@ -408,7 +407,7 @@ public class Graph extends Resource {
      */
     public String makeGraphPublic() throws Exception {
     	this.isGraphPublic = true;
-    	return updateGraph();
+    	return updateGraph().getResponseStatus();
     }
     
     /**
@@ -418,7 +417,7 @@ public class Graph extends Resource {
      */
     public String makeGraphPrivate() throws Exception {
     	this.isGraphPublic = false;
-    	return updateGraph();
+    	return updateGraph().getResponseStatus();
     }
     
 	/**

--- a/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/Graph.java
+++ b/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/Graph.java
@@ -339,7 +339,7 @@ public class Graph extends Resource {
      * @return response status on post request to GraphSpace
      * @throws Exception
      */
-    public String postGraph() throws Exception{
+    public Response postGraph() throws Exception{
     	if(this.graphJson == null) {
     		throw new GraphException(ExceptionCode.BAD_REQUEST_FORMAT, ExceptionMessage.BAD_REQUEST_FORMAT_EXCEPTION,
     				"Graph JSON is not set.");
@@ -358,8 +358,7 @@ public class Graph extends Resource {
         	data.put("tags[]", tags);
         }
     	JSONObject jsonResponse = restClient.post(path, data);
-    	Response response = new Response(jsonResponse);
-    	return response.getResponseStatus();
+    	return new Response(jsonResponse);
     }
     
     /**

--- a/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/GraphSpaceClient.java
+++ b/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/GraphSpaceClient.java
@@ -163,7 +163,7 @@ public class GraphSpaceClient {
     /**
      * Reference: {@link org.graphspace.javaclient.Graph#updateGraph()}
      */
-    public String updateGraph(String graphName, JSONObject graphJson, JSONObject styleJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
+    public Response updateGraph(String graphName, JSONObject graphJson, JSONObject styleJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
     	Graph graph = new Graph(restClient, isGraphPublic);
     	graph.setGraphJson(graphJson);
     	graph.setStyleJson(styleJson);

--- a/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/GraphSpaceClient.java
+++ b/GraphSpaceJavaClient/src/main/java/org/graphspace/javaclient/GraphSpaceClient.java
@@ -148,7 +148,7 @@ public class GraphSpaceClient {
     /**
      * Reference: {@link org.graphspace.javaclient.Graph#postGraph()}
      */
-    public String postGraph(JSONObject graphJson, JSONObject styleJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
+    public Response postGraph(JSONObject graphJson, JSONObject styleJson, boolean isGraphPublic, ArrayList<String> tagsList) throws Exception{
     	Graph graph = new Graph(restClient, isGraphPublic);
     	graph.setGraphJson(graphJson);
     	graph.setStyleJson(styleJson);


### PR DESCRIPTION
Overview: Creates a simple result panel that shows the status of the CyGraphSpace tasks.

CyGraphSpace version: 1.0.0 beta -> 1.0.1 beta

Result panel:
- Each time user uploads/update a new graph to GraphSpace, a new task is shown in the result panel.
- task information includes: task id, graph name, task status (in progress, complete, fail), and link to the graph if complete.

Other:
- Remove pop-up window for confirming user that graph has uploaded etc.
- Small changes to the Java client to return more information than just response code.

![image](https://user-images.githubusercontent.com/14338820/43040037-eaed2b28-8d07-11e8-8311-48ca67bdc0c8.png)

